### PR TITLE
Add mkdocs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,16 @@
 This repository contains the documentation of the Project Mu.  
 
 You can find the documentation at https://microsoft.github.io/mu/.
+
+# How to build the docs
+We are using [**MkDocs**](https://www.mkdocs.org) to build the documentation.
+
+The following gives you a rough overview how to serve it locally:
+* [Install MkDocs](https://www.mkdocs.org/#installation)
+* Run `pip install -r requirements.txt`
+* Execute `mkbuild serve`
+
+Now you should be able to open http://127.0.0.1:8000 on your machine.
+
+A more detailed information how to build this project can be found
+[here](https://microsoft.github.io/mu/DeveloperDocs/build_community_docs/).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
+[![Build status](https://dev.azure.com/projectmu/mu/_apis/build/status/Publish%20Mu)](https://dev.azure.com/projectmu/mu/_build/latest?definitionId=3)
+
 # Project Mu
 This repository documents Project Mu.  
 
-Start here: https://microsoft.github.io/mu/ 
-
-[![Build status](https://dev.azure.com/projectmu/mu/_apis/build/status/Publish%20Mu)](https://dev.azure.com/projectmu/mu/_build/latest?definitionId=3)
-
+Start here: https://microsoft.github.io/mu/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build status](https://dev.azure.com/projectmu/mu/_apis/build/status/Publish%20Mu)](https://dev.azure.com/projectmu/mu/_build/latest?definitionId=3)
 
 # Project Mu
-This repository contains the documentation of the Project Mu.  
+This repository contains documentation of the Project Mu.  
 
 You can find the documentation at https://microsoft.github.io/mu/.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We are using [**MkDocs**](https://www.mkdocs.org) to build the documentation.
 
 The following gives you a rough overview how to serve it locally:
 * Run `pip install -r requirements.txt`
-* Execute `mkbuild serve`
+* Execute `mkdocs serve`
 
 Now you should be able to open http://127.0.0.1:8000 on your machine.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ You can find the documentation at https://microsoft.github.io/mu/.
 We are using [**MkDocs**](https://www.mkdocs.org) to build the documentation.
 
 The following gives you a rough overview how to serve it locally:
-* [Install MkDocs](https://www.mkdocs.org/#installation)
 * Run `pip install -r requirements.txt`
 * Execute `mkbuild serve`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build status](https://dev.azure.com/projectmu/mu/_apis/build/status/Publish%20Mu)](https://dev.azure.com/projectmu/mu/_build/latest?definitionId=3)
 
 # Project Mu
-This repository documents Project Mu.  
+This repository contains the documentation of the Project Mu.  
 
-Start here: https://microsoft.github.io/mu/
+You can find the documentation at https://microsoft.github.io/mu/.

--- a/azure-pipelines-pr-gate.yml
+++ b/azure-pipelines-pr-gate.yml
@@ -26,8 +26,8 @@ steps:
     versionSpec: '3.7'
     architecture: 'x64'
 
-- script: python -m pip install --upgrade pip mkdocs
-  displayName: 'Install tools'
+- script: python -m pip install --upgrade pip
+  displayName: 'Install/Upgrade tools'
 
 - script: python -m pip install -r requirements.txt
   displayName: 'Install dependencies'

--- a/azure-pipelines-pr-gate.yml
+++ b/azure-pipelines-pr-gate.yml
@@ -20,14 +20,17 @@ steps:
 
 - script: cspell docs/**/*.md
   displayName: 'Spell Check md files'
-  
+
 - task: UsePythonVersion@0
   inputs:
     versionSpec: '3.7'
     architecture: 'x64'
 
-- script: python -m pip install --upgrade pip mkdocs mkdocs-macros-plugin mkdocs-material pymdown-extensions
+- script: python -m pip install --upgrade pip mkdocs
   displayName: 'Install tools'
+
+- script: python -m pip install -r requirements.txt
+  displayName: 'Install dependencies'
 
 - task: CmdLine@1
   displayName: 'build'

--- a/docs/DeveloperDocs/build_community_docs.md
+++ b/docs/DeveloperDocs/build_community_docs.md
@@ -21,10 +21,7 @@ git clone https://github.com/Microsoft/mu.git
     ```
 4. Install dependencies.
     ``` cmd
-    pip install mkdocs
-    pip install mkdocs-material
-    pip install mkdocs-macros-plugin
-    pip install pymdown-extensions
+    pip install -r requirements.txt
     ```
 
 5. if wanting to use spell check
@@ -69,7 +66,7 @@ One great feature of mkdocs is how easy it is to locally serve the docs to valid
 1. Use mkdocs to serve your local copy
     ``` cmd
     mkdocs serve
-    ``` 
+    ```
 2. navigate to 127.0.0.1:8000 in web browser
 
 ## Conventions and lessons learned

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,4 +72,3 @@ nav:
 
   - FAQ: 'faq.md'
   - License: 'license.md'
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+mkdocs
+mkdocs-material
+mkdocs-macros-plugin
+pymdown-extensions


### PR DESCRIPTION
I've updated the README which now contains the information how to build the documentation.
Additionally I've moved all dependencies into a `requirements.txt`...