### PR TITLE
main.py: Fix date format of `buildtime()` (ISO 8601)

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ def declare_variables(variables, macro):
     import datetime
     @macro
     def buildtime():
-      return str(datetime.datetime.now().strftime("%m-%d-%Y %H:%M"))
+      return str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M"))
 
 ''' 
 


### PR DESCRIPTION
Hyphens indicate ISO 8601:
https://www.iso.org/iso-8601-date-and-time-format.html