### PR TITLE
Fix yaml TOC generation bug when folder has "." in it

### DIFF
--- a/DocBuild.py
+++ b/DocBuild.py
@@ -505,7 +505,7 @@ class DocBuild(object):
         root = NavTree()
         for a in self.MdFiles:
             string1 = a.replace(os.sep, "/")
-            string2 = string1.partition(".")[0]
+            string2 = string1.rpartition(".")[0] # remove the md extension
             # this is intentionally not os.sep
             root.AddToTree(string2, DocBuild.DYNFOLDER + "/" + string1)
         logging.debug(root)

--- a/DocBuild.py
+++ b/DocBuild.py
@@ -505,7 +505,7 @@ class DocBuild(object):
         root = NavTree()
         for a in self.MdFiles:
             string1 = a.replace(os.sep, "/")
-            string2 = string1.rpartition(".")[0] # remove the md extension
+            string2 = string1.rpartition(".")[0]  # remove the md extension
             # this is intentionally not os.sep
             root.AddToTree(string2, DocBuild.DYNFOLDER + "/" + string1)
         logging.debug(root)


### PR DESCRIPTION
edk2 now has folders like ".pytool" and ".azurepipelines".  These folders break a bad assumption that a path would only have 1 "." in it.  This change uses python right partition to split on the last "." instead of the first.  