### PR TITLE
Update edk2-pytool links

### DIFF
--- a/docs/CodeDevelopment/compile.md
+++ b/docs/CodeDevelopment/compile.md
@@ -11,8 +11,8 @@ dependencies, updating git dependencies, and other functions.  Project Mu has tw
 will be described here to encourage pattern/code reuse and limit the required repository specific documentation.  More
 details for pytools can be found here:
 
-* <https://github.com/tianocore/edk2-pytool-extensions/tree/master/docs>
-* <https://github.com/tianocore/edk2-pytool-library/tree/master/docs>
+* <https://www.tianocore.org/edk2-pytool-extensions/>
+* <https://www.tianocore.org/edk2-pytool-library/>
 
 ## CI multi-package Building and Testing aka **stuart_ci_build**
 

--- a/docs/CodeDevelopment/prerequisites.md
+++ b/docs/CodeDevelopment/prerequisites.md
@@ -95,7 +95,7 @@ git operations if you have multiple workspaces by using the git "--reference" fe
 
 ## Windows Subsystem For Linux (WSL) and Linux
 
-Basic directions here. <https://github.com/tianocore/edk2-pytool-extensions/blob/master/docs/usability/using_linux.md>
+Basic directions here. <https://www.tianocore.org/edk2-pytool-extensions/features/using_linux/>
 
 ## All Operating Systems - Python Virtual Environment and PyTools
 

--- a/docs/How/integration_checklist.md
+++ b/docs/How/integration_checklist.md
@@ -86,7 +86,7 @@ the history clean and readable.
 * Trigger the actual release once the build passes
 * Tag the commit that these were released from
 * Update the Basetools version and re-enable the extdep
-* [See here](https://github.com/tianocore/edk2-pytool-extensions/blob/master/docs/usability/using_extdep.md) for more
+* [See here](https://www.tianocore.org/edk2-pytool-extensions/features/extdep/) for more
   details
 
 ### f) Run Testing


### PR DESCRIPTION
Edk2-Pytools has transitioned to published docs, so this updates the links referencing Edk2-Pytools to point at the docs rather than the github markdown files.