### PR TITLE
.gitignore: Ignore generated log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ __pycache__/
 
 # yml file - build process builds it
 /mkdocs.yml
+
+# ignore generated log files
+*.log


### PR DESCRIPTION
Ignores log files that are generated when running `DocBuild.py`.