### PR TITLE
Add Rust install steps to prerequisites

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -130,6 +130,7 @@
         "rlib",
         "roadmap",
         "roadmaps",
+        "rustc",
         "rustfmt",
         "rustup",
         "signtool",

--- a/docs/CodeDevelopment/prerequisites.md
+++ b/docs/CodeDevelopment/prerequisites.md
@@ -72,6 +72,11 @@ See component list here for more options. <https://docs.microsoft.com/en-us/visu
 
 See component list here for more options. <https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2019>
 
+### Rust 
+
+Follow the Rust [install steps](/mu/CodeDevelopment/rust_build#generally-getting-started-with-rust) to install all required tooling. This generally
+includes: `rustc`, `cargo`, `cargo-make`, and `cargo-tarpaulin`
+
 ### Optional - Windows Driver Kit
 
 Provides Inf2Cat.exe, needed to [prepare Windows firmware update packages for signing](https://docs.microsoft.com/en-us/windows-hardware/drivers/bringup/certifying-and-signing-the-update-package).

--- a/docs/CodeDevelopment/prerequisites.md
+++ b/docs/CodeDevelopment/prerequisites.md
@@ -72,10 +72,10 @@ See component list here for more options. <https://docs.microsoft.com/en-us/visu
 
 See component list here for more options. <https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2019>
 
-### Rust 
+### Rust
 
-Follow the Rust [install steps](/mu/CodeDevelopment/rust_build#generally-getting-started-with-rust) to install all required tooling. This generally
-includes: `rustc`, `cargo`, `cargo-make`, and `cargo-tarpaulin`
+Follow the Rust [install steps](/mu/CodeDevelopment/rust_build#generally-getting-started-with-rust) to install all
+required tooling. This generally includes: `rustc`, `cargo`, `cargo-make`, and `cargo-tarpaulin`
 
 ### Optional - Windows Driver Kit
 

--- a/docs/CodeDevelopment/rust_build.md
+++ b/docs/CodeDevelopment/rust_build.md
@@ -67,8 +67,8 @@ by following the instructions in the "Default Tasks and Extending" section of th
 
 Note that the file path to the Mu Basecore file will be relative to the project's own makefile.
 
-The `rustfmt.toml` and `rust-toolchain.toml` files synced across Project Mu repos defines the common formatting options expected for Rust code in
-other Project Mu based repositories.
+The `rustfmt.toml` and `rust-toolchain.toml` files synced across Project Mu repos defines the supported rust version
+common formatting options expected for Rust code in other Project Mu based repositories.
 
 ## Dev Container (with Rust)
 

--- a/docs/CodeDevelopment/rust_build.md
+++ b/docs/CodeDevelopment/rust_build.md
@@ -22,25 +22,29 @@ It is recommended to:
 
    \>`cargo --version`
 
-4. Install the desired Rust tool chain
+4. Install the desired Rust tool chain. The version is found in the `rust-toolchain.toml` file at the root of the repository.
 
-   - Example: `1.68.2 x86_64 toolchain`
+   - [Exampe](https://github.com/microsoft/mu_tiano_platforms/blob/main/rust-toolchain.toml): `1.73.0 x86_64 toolchain`
 
    - Windows:
 
-      \>`rustup toolchain install 1.68.2-x86_64-pc-windows-msvc`
+      \>`rustup toolchain install 1.73.0-x86_64-pc-windows-msvc`
 
-      \>`rustup component add rust-src --toolchain 1.68.2-x86_64-pc-windows-msvc`
+      \>`rustup component add rust-src --toolchain 1.73.0-x86_64-pc-windows-msvc`
 
    - Linux:
 
-      \>`rustup toolchain install 1.68.2-x86_64-unknown-linux-gnu`
+      \>`rustup toolchain install 1.73.0-x86_64-unknown-linux-gnu`
 
-      \>`rustup component add rust-src --toolchain 1.68.2-x86_64-unknown-linux-gnu`
+      \>`rustup component add rust-src --toolchain 1.73.0-x86_64-unknown-linux-gnu`
 
 5. Install `cargo make`
 
    \>`cargo install --force cargo-make`
+
+6. Install `cargo tarpaulin`
+
+   \>`cargo install --force cargo-tarpaulin`
 
 At this point, the essential Rust applications are installed, and a repo can begin to add and build Rust code.
 
@@ -49,10 +53,12 @@ At this point, the essential Rust applications are installed, and a repo can beg
 Currently, two files are provided in Project Mu repos that play an important role in the building and formatting of
 Rust code in Project Mu based repositories.
 
-- `Makefile.toml` - Defines the tasks and environment settings use within the Project Mu build system to bui;d and
+- `Makefile.toml` - Defines the tasks and environment settings use within the Project Mu build system to build and
   test code.
 
 - `rustfmt.toml` - Defines Rust formatting options used.
+
+- `rust-toolchain.toml` - Defines the exact toolchain supported for this repository
 
 Project Mu repos have common files automatically synced from a common source in the [Mu DevOps](https://github.com/microsoft/mu_devops)
 repo. Projects downstream to Project Mu are recommended to "extend" the `Makefile.toml` in [Mu Basecore](https://github.com/microsoft/mu_basecore)
@@ -61,7 +67,7 @@ by following the instructions in the "Default Tasks and Extending" section of th
 
 Note that the file path to the Mu Basecore file will be relative to the project's own makefile.
 
-The `rustfmt.toml` file synced across Project Mu repos defines the common formatting options expected for Rust code in
+The `rustfmt.toml` and `rust-toolchain.toml` files synced across Project Mu repos defines the common formatting options expected for Rust code in
 other Project Mu based repositories.
 
 ## Dev Container (with Rust)

--- a/docs/CodeDevelopment/rust_build.md
+++ b/docs/CodeDevelopment/rust_build.md
@@ -22,7 +22,8 @@ It is recommended to:
 
    \>`cargo --version`
 
-4. Install the desired Rust tool chain. The version is found in the `rust-toolchain.toml` file at the root of any Project Mu repository.
+4. Install the desired Rust tool chain. The version is found in the `rust-toolchain.toml` file at the root of any
+   Project Mu repository.
 
    - [Example](https://github.com/microsoft/mu_tiano_platforms/blob/main/rust-toolchain.toml): `1.73.0 x86_64 toolchain`
 

--- a/docs/CodeDevelopment/rust_build.md
+++ b/docs/CodeDevelopment/rust_build.md
@@ -23,7 +23,8 @@ It is recommended to:
    \>`cargo --version`
 
 4. Install the desired Rust tool chain. The version is found in the `rust-toolchain.toml` file at the root of any
-   Project Mu repository.
+   Project Mu repository that contains Rust code.
+
 
    - [Example](https://github.com/microsoft/mu_tiano_platforms/blob/main/rust-toolchain.toml): `1.73.0 x86_64 toolchain`
 

--- a/docs/CodeDevelopment/rust_build.md
+++ b/docs/CodeDevelopment/rust_build.md
@@ -25,7 +25,6 @@ It is recommended to:
 4. Install the desired Rust tool chain. The version is found in the `rust-toolchain.toml` file at the root of any
    Project Mu repository that contains Rust code.
 
-
    - [Example](https://github.com/microsoft/mu_tiano_platforms/blob/main/rust-toolchain.toml): `1.73.0 x86_64 toolchain`
 
    - Windows:

--- a/docs/CodeDevelopment/rust_build.md
+++ b/docs/CodeDevelopment/rust_build.md
@@ -22,9 +22,9 @@ It is recommended to:
 
    \>`cargo --version`
 
-4. Install the desired Rust tool chain. The version is found in the `rust-toolchain.toml` file at the root of the repository.
+4. Install the desired Rust tool chain. The version is found in the `rust-toolchain.toml` file at the root of any Project Mu repository.
 
-   - [Exampe](https://github.com/microsoft/mu_tiano_platforms/blob/main/rust-toolchain.toml): `1.73.0 x86_64 toolchain`
+   - [Example](https://github.com/microsoft/mu_tiano_platforms/blob/main/rust-toolchain.toml): `1.73.0 x86_64 toolchain`
 
    - Windows:
 


### PR DESCRIPTION
Add a link to the rust install steps section of the rust_build.md document to the prerequisites.md document so that it obvious to readers that they must also install the rust requirements.