### PR TITLE
Update Pipeline for newer PublishCodeCoverageResults task.

### DIFF
--- a/azure-pipelines-pr-gate.yml
+++ b/azure-pipelines-pr-gate.yml
@@ -2,7 +2,7 @@ workspace:
   clean: all
 
 pool:
-  vmImage: windows-2022
+  vmImage: windows-latest
 
 steps:
 - task: DeleteFiles@1
@@ -71,11 +71,9 @@ steps:
 
 # Publish Code Coverage Results
 # Publish Cobertura code coverage results
-- task: PublishCodeCoverageResults@1
+- task: PublishCodeCoverageResults@2
   inputs:
-    codeCoverageTool: 'cobertura' # Options: cobertura, jaCoCo
     summaryFileLocation: $(System.DefaultWorkingDirectory)/cov.xml
-    reportDirectory: $(System.DefaultWorkingDirectory)/cov_html
   condition: succeededOrFailed()
 
 - script: flake8 . > flake8.err.log


### PR DESCRIPTION
PublishCodeCoverageResults@1 is depreciated.
Moving task to use PublishCodeCoverageResults@2.

https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/publish-code-coverage-results-v2?view=azure-pipelines

Pipeline is reporting that the PublishCodeCoverageResults@1 task is depreciated.