### PR TITLE
Repo File Sync: Update DocBuild File is not always closed

### DIFF
--- a/DocBuild.py
+++ b/DocBuild.py
@@ -433,21 +433,22 @@ class DocBuild(object):
         return 0
 
     def MakeYml(self):
-        ymlbase = open(self.YmlFilePathBase, "r")
-        yamlout = open(self.YmlFilePathOut, 'w')
-        for line in ymlbase:
-            yamlout.write(line)
+        with open(self.YmlFilePathBase, "r") as ymlbase:
+            with open(self.YmlFilePathOut, 'w') as yamlout:
+                for line in ymlbase:
+                    yamlout.write(line)
 
-        # now parse as yaml
-        ymlbase.seek(0)
-        # yaml.load(f)
-        # IMPORTANT NOTE: This call to "unsafe_load()" is only acceptable because we control the yml file being loaded.
-        #                   Unsafe load is required to support some configuration options for pymdownx.
-        if "extra" in yaml.unsafe_load(ymlbase):
-            raise Exception(
-                "extra: member not allowed in mkdocs_base.yml.  Please add the contents to DocBuild constructor instead.  ")
-        ymlbase.close()
-        self.Yml = yamlout
+                # now parse as yaml
+                ymlbase.seek(0)
+                # yaml.load(f)
+                # IMPORTANT NOTE: This call to "unsafe_load()" is only acceptable because we control the yml file being loaded.
+                #                   Unsafe load is required to support some configuration options for pymdownx.
+                if "extra" in yaml.unsafe_load(ymlbase):
+                    raise Exception(
+                        "extra: member not allowed in mkdocs_base.yml.  Please add the contents to DocBuild constructor instead.  ")
+
+        # Re-open output YAML file for further use elsewhere; this handle will be closed in CloseYml.
+        self.Yml = open(self.YmlFilePathOut, 'a')
 
     def CloseYml(self):
         if self.Yml is not None:


### PR DESCRIPTION
Fix issue problem the file opens in `MakeYml` should be wrapped in `with` context managers so they are always closed, even if an exception occurs. We still need to preserve current behavior: copy all lines from the base YAML file into the output file, then parse the base YAML from the beginning to check for an `extra` key, raise if present, and finally keep an open handle to the output YAML in `self.Yml` for later use by `CloseYml`.

The safest change is:
- Open `self.YmlFilePathBase` with `with open(..., 'r') as ymlbase:` so that it is always closed after use.
- Within that `with`, open `self.YmlFilePathOut` with another `with open(..., 'w') as yamlout:` and perform the line copy and YAML parse while both files are open and automatically managed.
- After the nested `with` blocks, reopen `self.YmlFilePathOut` in append mode (`'a'`) and assign that handle to `self.Yml`. This preserves the design where `self.Yml` stays open beyond `MakeYml` and will be closed in `CloseYml`, without risking leaks if an exception occurs during the initial processing.
- Remove the explicit `ymlbase.close()` and the assignment `self.Yml = yamlout` inside `MakeYml`, since those handles are now managed by context managers and a fresh handle is created for `self.Yml`.

[Reading and writing files](https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files)
[The with statement, The try statement](http://docs.python.org/reference/compound_stmts.html#the-with-statement)
[Python PEP 343 The "with" Statement](http://www.python.org/dev/peps/pep-0343)
CWE-772